### PR TITLE
Fix panic on Arrays and Objects

### DIFF
--- a/oj/array.go
+++ b/oj/array.go
@@ -33,7 +33,11 @@ func (n Array) Alter() interface{} {
 	if n != nil {
 		simple = *(*[]interface{})(unsafe.Pointer(&n))
 		for i, m := range n {
-			simple[i] = m.Alter()
+			if m == nil {
+				simple[i] = nil
+			} else {
+				simple[i] = m.Alter()
+			}
 		}
 	}
 	return simple
@@ -45,7 +49,11 @@ func (n Array) Simplify() interface{} {
 	if n != nil {
 		dup = make([]interface{}, 0, len(n))
 		for _, m := range n {
-			dup = append(dup, m.Simplify())
+			if m == nil {
+				dup = append(dup, nil)
+			} else {
+				dup = append(dup, m.Simplify())
+			}
 		}
 	}
 	return dup

--- a/oj/array_test.go
+++ b/oj/array_test.go
@@ -17,17 +17,17 @@ func TestArrayString(t *testing.T) {
 }
 
 func TestArraySimplify(t *testing.T) {
-	a := oj.Array{oj.Int(3), oj.Int(7)}
+	a := oj.Array{oj.Int(3), oj.Int(7), nil}
 	simple := a.Simplify()
 
-	tt.Equal(t, "[]interface {} [3 7]", fmt.Sprintf("%T %v", simple, simple))
+	tt.Equal(t, "[]interface {} [3 7 <nil>]", fmt.Sprintf("%T %v", simple, simple))
 }
 
 func TestArrayAlter(t *testing.T) {
-	a := oj.Array{oj.Int(3), oj.Int(7)}
+	a := oj.Array{oj.Int(3), oj.Int(7), nil}
 	alt := a.Alter()
 
-	tt.Equal(t, "[]interface {} [3 7]", fmt.Sprintf("%T %v", alt, alt))
+	tt.Equal(t, "[]interface {} [3 7 <nil>]", fmt.Sprintf("%T %v", alt, alt))
 
 	aa := alt.([]interface{})
 	tt.Equal(t, "int64 3  int64 7", fmt.Sprintf("%T %v  %T %v", aa[0], aa[0], aa[1], aa[1]))

--- a/oj/object.go
+++ b/oj/object.go
@@ -64,7 +64,11 @@ func (n Object) Alter() interface{} {
 	if n != nil {
 		simple = *(*map[string]interface{})(unsafe.Pointer(&n))
 		for k, m := range n {
-			simple[k] = m.Alter()
+			if m == nil {
+				simple[k] = nil
+			} else {
+				simple[k] = m.Alter()
+			}
 		}
 	}
 	return simple
@@ -76,7 +80,11 @@ func (n Object) Simplify() interface{} {
 	if n != nil {
 		dup = map[string]interface{}{}
 		for k, m := range n {
-			dup[k] = m.Simplify()
+			if m == nil {
+				dup[k] = m
+			} else {
+				dup[k] = m.Simplify()
+			}
 		}
 	}
 	return dup
@@ -88,7 +96,11 @@ func (n Object) Dup() Node {
 	if n != nil {
 		o = Object{}
 		for k, m := range n {
-			o[k] = m.Dup()
+			if m == nil {
+				o[k] = nil
+			} else {
+				o[k] = m.Dup()
+			}
 		}
 	}
 	return o

--- a/oj/object_test.go
+++ b/oj/object_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestObjectString(t *testing.T) {
 	oj.Sort = true
-	o := oj.Object{"a": oj.Int(3), "b": oj.Object{"c": oj.Int(5)}, "d": oj.Int(7)}
-	tt.Equal(t, `{"a":3,"b":{"c":5},"d":7}`, o.String())
+	o := oj.Object{"a": oj.Int(3), "b": oj.Object{"c": oj.Int(5)}, "d": oj.Int(7), "n": nil}
+	tt.Equal(t, `{"a":3,"b":{"c":5},"d":7,"n":null}`, o.String())
 
 	oj.Sort = false
 	o = oj.Object{"a": nil, "b": oj.Int(7)}
@@ -23,7 +23,7 @@ func TestObjectString(t *testing.T) {
 }
 
 func TestObjectSimplify(t *testing.T) {
-	o := oj.Object{"a": oj.Int(3), "b": oj.Int(7)}
+	o := oj.Object{"a": oj.Int(3), "b": oj.Int(7), "n": nil}
 	simple := o.Simplify()
 
 	tt.Equal(t, "map[string]interface {}", fmt.Sprintf("%T", simple))
@@ -32,7 +32,7 @@ func TestObjectSimplify(t *testing.T) {
 }
 
 func TestObjectAlter(t *testing.T) {
-	o := oj.Object{"a": oj.Int(3), "b": oj.Int(7)}
+	o := oj.Object{"a": oj.Int(3), "b": oj.Int(7), "n": nil}
 	alt := o.Alter()
 
 	tt.Equal(t, "map[string]interface {}", fmt.Sprintf("%T", alt))
@@ -43,11 +43,11 @@ func TestObjectAlter(t *testing.T) {
 
 func TestObjectDup(t *testing.T) {
 	oj.Sort = true
-	o := oj.Object{"a": oj.Int(3), "b": oj.Int(7)}
+	o := oj.Object{"a": oj.Int(3), "b": oj.Int(7), "n": nil}
 
 	dup := o.Dup()
 	tt.NotNil(t, dup)
-	tt.Equal(t, `{"a":3,"b":7}`, dup.String())
+	tt.Equal(t, `{"a":3,"b":7,"n":null}`, dup.String())
 }
 
 func TestObjectEmpty(t *testing.T) {


### PR DESCRIPTION
Arrays and objects containing nil members panic without an additional
check for nil in the dup, simplify and alter functions.