### PR TITLE
Add option to display undefined keys as null in Get

### DIFF
--- a/jp/get.go
+++ b/jp/get.go
@@ -16,6 +16,10 @@ const (
 	descentChildFlag = 0x00020000
 )
 
+// EnableUndefined allows Get to return a "null" string for child elements with 
+// an undefined key in relation to the expression.
+var EnableUndefined bool
+
 type fragIndex int
 
 // The easy way to implement the Get is to have each fragment handle the
@@ -59,16 +63,13 @@ func (x Expr) Get(data interface{}) (results []interface{}) {
 			switch tv := prev.(type) {
 			case nil:
 			case map[string]interface{}:
-				v = tv[string(tf)]
-
-				// always enable to allow for undefined data elements
-				has = true
+				v, has = tv[string(tf)]
 			case gen.Object:
 				v, has = tv[string(tf)]
 			default:
 				v, has = x.reflectGetChild(tv, string(tf))
 			}
-			if has {
+			if has || EnableUndefined {
 				if int(fi) == len(x)-1 { // last one
 					results = append(results, v)
 				} else {

--- a/jp/get.go
+++ b/jp/get.go
@@ -59,7 +59,10 @@ func (x Expr) Get(data interface{}) (results []interface{}) {
 			switch tv := prev.(type) {
 			case nil:
 			case map[string]interface{}:
-				v, has = tv[string(tf)]
+				v = tv[string(tf)]
+
+				// always enable to allow for undefined data elements
+				has = true
 			case gen.Object:
 				v, has = tv[string(tf)]
 			default:

--- a/jp/get_test.go
+++ b/jp/get_test.go
@@ -437,6 +437,28 @@ func buildNodeTree(size, depth, iv int) gen.Node {
 	return obj
 }
 
+func TestExprGetUndefined(t *testing.T) {
+	jp.EnableUndefined = true
+
+	obj, err := oj.ParseString(`{
+	"a":[
+		{"x":1,"y":2,"z":3},
+		{"x":2,"y":4},
+		{}
+	]
+}`)
+	tt.Nil(t, err)
+	x, _ := jp.ParseString("$.a[:].z")
+	ys := x.Get(obj)
+	tt.Equal(t, "[3,null,null]", oj.JSON(ys))
+
+	x, _ = jp.ParseString("$.a[:].x")
+	ys = x.Get(obj)
+	tt.Equal(t, "[1,2,null]", oj.JSON(ys))
+
+	jp.EnableUndefined = false
+}
+
 func TestExprGetWildArray(t *testing.T) {
 	obj, err := oj.ParseString(`{
   "a":[


### PR DESCRIPTION
Example:
```json
"a":[{"x": 1}, {}]
```
When ```EnableUndefined = true``` , an expression such as ```$.a[:].x``` will result in ```[1,"null"]``` instead of ```[1]```