### PR TITLE
Fix decompose type aliases, stack overflow during Marshal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The structure and content of this file follows [Keep a Changelog](https://keepac
 ## [1.10.1] - unreleased
 ### Fixed
 - Struct with pointers to base types such as *float64 are fixed.
+- Stack overflow when converting values to JSON which are a type alias of a
+  builtin.
 ### Added
 - Added `[]byte` converation option for decompose.
 - Added MustXxx versions of multiple functions to allow a panic and recover code pattern.

--- a/alt/decompose.go
+++ b/alt/decompose.go
@@ -163,8 +163,16 @@ func reflectValue(rv reflect.Value, val interface{}, opt *Options) (v interface{
 		v = reflectArray(rv, opt)
 	case reflect.Struct:
 		v = reflectStruct(rv, val, opt)
-	default:
-		v = val
+	case reflect.String:
+		v = rv.String()
+	case reflect.Bool:
+		v = rv.Bool()
+	case reflect.Float32, reflect.Float64:
+		v = rv.Float()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v = rv.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v = rv.Uint()
 	}
 	return
 }

--- a/alt/decompose_test.go
+++ b/alt/decompose_test.go
@@ -3,6 +3,7 @@
 package alt_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -197,6 +198,27 @@ func TestDecomposeTime(t *testing.T) {
 	a := []interface{}{tm}
 	v := alt.Decompose(a, &ojg.Options{TimeFormat: "nano"})
 	tt.Equal(t, []interface{}{1612872794000000000}, v)
+}
+
+func TestDecomposeAliasedTypes(t *testing.T) {
+	type Stringy string
+	type Inty int
+	type Uinty uint
+	type Floaty float64
+	type Booly bool
+	tcs := [][]interface{}{
+		{Stringy("stringy"), "stringy"},
+		{Inty(1), 1},
+		{Uinty(1), uint(1)},
+		{Floaty(1.3), 1.3},
+		{Booly(true), true},
+	}
+	for i, tc := range tcs {
+		input := tc[0]
+		expect := tc[1]
+		dec := alt.Decompose(input)
+		tt.Equal(t, expect, dec, fmt.Sprintf("case %d failed", i))
+	}
 }
 
 func TestAlterNumbers(t *testing.T) {

--- a/oj/writer_test.go
+++ b/oj/writer_test.go
@@ -427,6 +427,14 @@ func TestMarshalMap(t *testing.T) {
 	tt.Equal(t, `{"M":{"a":{"Val":1}}}`, string(j))
 }
 
+func TestMarshalTypeAlias(t *testing.T) {
+	type Stringy string
+	d := Stringy("s")
+	j, err := oj.Marshal(&d)
+	tt.Nil(t, err)
+	tt.Equal(t, `"s"`, string(j))
+}
+
 func BenchmarkMarshalFlat(b *testing.B) {
 	m := Mix{
 		Val:   1,


### PR DESCRIPTION
This patch adds missing cases to the decompose reflectValue method to
handle conversion of type aliases to their underlying type. This fixes
behavior in alt.Decompose and also prevents a stack overflow occurring
with `oj.JSON` and `oj.Marshal` where an infinite loop occurs trying to
decompose a type alias to a Go builtin type.