### PR TITLE
Accept hyphens in jsonpath

### DIFF
--- a/jp/parse.go
+++ b/jp/parse.go
@@ -15,7 +15,7 @@ const (
 	//   0123456789abcdef0123456789abcdef
 	tokenMap = "" +
 		"................................" + // 0x00
-		"...o.o..........oooooooooooo...o" + // 0x20
+		"...o.o.......o..oooooooooooo...o" + // 0x20
 		".oooooooooooooooooooooooooo...oo" + // 0x40
 		".oooooooooooooooooooooooooooooo." + // 0x60
 		"oooooooooooooooooooooooooooooooo" + // 0x80

--- a/jp/parse_test.go
+++ b/jp/parse_test.go
@@ -32,6 +32,7 @@ func TestParse(t *testing.T) {
 		{src: "@.*", expect: "@.*"},
 		{src: "[1,2]", expect: "[1,2]"},
 		{src: "abc..def", expect: "abc..def"},
+		{src: "abc-def", expect: "abc-def"},
 		{src: "abc[*].def", expect: "abc[*].def"},
 		{src: "abc[0].def", expect: "abc[0].def"},
 		{src: "abc[-1].def", expect: "abc[-1].def"},


### PR DESCRIPTION
This pr adds hyphens ("`-`") in the map of allowed characters in jsonpath.

According to the provided test, some jsonpath such as `$.foo-bar` are now possible :)