### PR TITLE
Quote empty strings in JSON Paths

### DIFF
--- a/jp/child.go
+++ b/jp/child.go
@@ -33,7 +33,7 @@ func (f Child) tokenOk() bool {
 			return false
 		}
 	}
-	return true
+	return len(f) != 0
 }
 
 func (f Child) remove(value any) (out any, changed bool) {

--- a/jp/expr_test.go
+++ b/jp/expr_test.go
@@ -59,6 +59,8 @@ func TestExprBuild(t *testing.T) {
 	x = jp.R().Child("'")
 	tt.Equal(t, `$['\'']`, x.String())
 
+	x = jp.R().Child("").Child("a")
+	tt.Equal(t, `$[''].a`, x.String())
 }
 
 func TestExprFilter(t *testing.T) {


### PR DESCRIPTION
Fixing a small corner case for child with empty name

Without this, `jp.R().Child("").Child("a").String()` results in `$..a`, which is a recursive descent.

Instead it should return `$[''].a`