### PR TITLE
jp.reflectGetChild function enhanced

### DIFF
--- a/jp/get.go
+++ b/jp/get.go
@@ -1587,7 +1587,7 @@ func (x Expr) reflectGetChild(data any, key string) (v any, has bool) {
 		}
 		switch rt.Kind() {
 		case reflect.Struct:
-			rv := rd.FieldByNameFunc(func(k string) bool { return strings.EqualFold(k, key) })
+			rv := reflectGetFieldByKey(rd, key)
 			if rv.IsValid() && rv.CanInterface() {
 				v = rv.Interface()
 				has = true
@@ -1598,6 +1598,144 @@ func (x Expr) reflectGetChild(data any, key string) (v any, has bool) {
 				v = rv.Interface()
 				has = true
 			}
+		}
+	}
+	return
+}
+
+func reflectGetFieldByKey(structValue reflect.Value, key string) reflect.Value {
+	if f, ok := reflectGetStructFieldByNameOrJsonTag(structValue, key); ok {
+		return structValue.FieldByIndex(f.Index)
+	}
+	return reflect.Value{}
+}
+
+func reflectGetStructFieldByNameOrJsonTag(structValue reflect.Value, key string) (result reflect.StructField, ok bool) {
+	if structValue.Type().Kind() != reflect.Struct {
+		panic("reflectGetStructFieldByNameOrJsonTag of non-struct type " + structValue.Type().String())
+	}
+
+	// match by field name or by json tag
+	match := func(f reflect.StructField) bool {
+		if strings.EqualFold(f.Name, key) {
+			return true
+		}
+		tagValue := f.Tag.Get("json")
+		jsonKey, _, _ := strings.Cut(tagValue, ",")
+		jsonKey = strings.Trim(jsonKey, " ")
+		if strings.EqualFold(jsonKey, key) {
+			return true
+		}
+		return false
+	}
+
+	type fieldScan struct {
+		structVal reflect.Value
+		index     []int
+	}
+
+	// -----------------------------------------------------------------
+	// The algorithm is breadth first search, one depth level at a time.
+	// Based on the original: ((Struct) reflect.Value).FieldByNameFunc()
+	// -----------------------------------------------------------------
+
+	// The 'current' and 'next' slices are work queues:
+	// 'current' lists the fields to visit on this depth level,
+	// and 'next' lists the fields on the next lower level.
+	current := []fieldScan{}
+	next := []fieldScan{{structVal: structValue}}
+
+	// 'nextCount' records the number of times an embedded struct type has been
+	// encountered and considered for queueing in the 'next' slice.
+	// We only queue the first one, but we increment the count on each.
+	// If a struct type T can be reached more than once at a given depth level,
+	// then it annihilates itself and need not be considered at all when we
+	// process that next depth level.
+	var nextCount map[reflect.Type]int
+
+	// 'visited' records the structs that have been considered already.
+	// Note that embedded pointer fields can create cycles in the graph of
+	// reachable embedded types; 'visited' avoids following those cycles.
+	// It also avoids duplicated effort: if we didn't find the field in an
+	// embedded type T at level 2, we won't find it in one at level 4 either.
+	visited := map[reflect.Type]bool{}
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count := nextCount
+		nextCount = nil
+
+		// Process all the fields at this depth, now listed in 'current'.
+		// The loop queues embedded fields found in 'next', for processing during the next
+		// iteration. The multiplicity of the 'current' field counts is recorded
+		// in 'count'; the multiplicity of the 'next' field counts is recorded in 'nextCount'.
+		for _, scan := range current {
+			sVal := scan.structVal
+			sTyp := sVal.Type()
+			if visited[sTyp] {
+				// We've looked through this type before, at a higher level.
+				// That higher level would shadow the lower level we're now at,
+				// so this one can't be useful to us. Ignore it.
+				continue
+			}
+			visited[sTyp] = true
+
+			for i := 0; i < sVal.NumField(); i++ {
+				f := sTyp.Field(i)
+
+				var nestedTyp reflect.Type
+				if f.Anonymous {
+					// Embedded field of type T or *T.
+					nestedTyp = f.Type
+					if nestedTyp.Kind() == reflect.Ptr {
+						nestedTyp = nestedTyp.Elem()
+					}
+				}
+
+				// Does it match?
+				if match(f) {
+					// Potential match
+					if count[sTyp] > 1 || ok {
+						// Name appeared multiple times at this level: annihilate.
+						return reflect.StructField{}, false
+					}
+					result = f
+					result.Index = nil
+					result.Index = append(result.Index, scan.index...)
+					result.Index = append(result.Index, i)
+					ok = true
+					continue
+				}
+
+				// Queue embedded struct fields for processing with next level,
+				// but only if we haven't seen a match yet at this level and only
+				// if the embedded types haven't already been queued.
+				if ok || nestedTyp == nil || nestedTyp.Kind() != reflect.Struct {
+					continue
+				}
+
+				nestedStructVal := sVal.Field(i)
+				nestedStructTyp := nestedStructVal.Type()
+
+				if nextCount[nestedStructTyp] > 0 {
+					nextCount[nestedStructTyp] = 2 // exact multiple doesn't matter
+					continue
+				}
+				if nextCount == nil {
+					nextCount = map[reflect.Type]int{}
+				}
+				nextCount[nestedStructTyp] = 1
+				if count[sTyp] > 1 {
+					nextCount[nestedStructTyp] = 2 // exact multiple doesn't matter
+				}
+				var index []int
+				index = append(index, scan.index...)
+				index = append(index, i)
+				next = append(next, fieldScan{structVal: nestedStructVal, index: index})
+			}
+		}
+		if ok {
+			break
 		}
 	}
 	return

--- a/jp/get.go
+++ b/jp/get.go
@@ -1666,7 +1666,8 @@ func reflectGetStructFieldByNameOrJsonTag(structValue reflect.Value, key string)
 		// The loop queues embedded fields found in 'next', for processing during the next
 		// iteration. The multiplicity of the 'current' field counts is recorded
 		// in 'count'; the multiplicity of the 'next' field counts is recorded in 'nextCount'.
-		for _, scan := range current {
+		for i := range current {
+			scan := current[i]
 			sVal := scan.structVal
 			sTyp := sVal.Type()
 			if visited[sTyp] {
@@ -1678,8 +1679,8 @@ func reflectGetStructFieldByNameOrJsonTag(structValue reflect.Value, key string)
 			visited[sTyp] = true
 
 			for i := 0; i < sVal.NumField(); i++ {
-				structField := sTyp.Field(i)
 				fieldValue := sVal.Field(i)
+				structField := sTyp.Field(i)
 
 				var nestedTyp reflect.Type
 				if structField.Anonymous {

--- a/jp/get_test.go
+++ b/jp/get_test.go
@@ -773,6 +773,98 @@ func TestGetWildReflectOrder(t *testing.T) {
 	tt.Equal(t, "e1", pretty.SEN(path.First(data)))
 }
 
+func TestGetChildReflectByJsonTag(t *testing.T) {
+	type Element struct {
+		Value string
+	}
+	type Root struct {
+		Elements    []Element
+		AltElements []Element `json:"anyOtherAttributeName"`
+	}
+	data := Root{
+		Elements: []Element{
+			{Value: "e1"},
+			{Value: "e2"},
+			{Value: "e3"},
+		},
+		AltElements: []Element{
+			{Value: "e4"},
+			{Value: "e5"},
+			{Value: "e6"},
+		},
+	}
+	path := jp.MustParseString("$.elements[*]")
+	tt.Equal(t, "[{value: e1} {value: e2} {value: e3}]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "{value: e1}", pretty.SEN(path.First(data)))
+
+	path = jp.MustParseString("$.elements[*].value")
+	tt.Equal(t, "[e1 e2 e3]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "e1", pretty.SEN(path.First(data)))
+
+	path = jp.MustParseString("$.altElements[*]")
+	tt.Equal(t, "[{value: e4} {value: e5} {value: e6}]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "{value: e4}", pretty.SEN(path.First(data)))
+
+	path = jp.MustParseString("$.altElements[*].value")
+	tt.Equal(t, "[e4 e5 e6]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "e4", pretty.SEN(path.First(data)))
+
+	// Get by "json" tag
+	path = jp.MustParseString("$.anyOtherAttributeName[*]")
+	tt.Equal(t, "[{value: e4} {value: e5} {value: e6}]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "{value: e4}", pretty.SEN(path.First(data)))
+
+	path = jp.MustParseString("$.anyOtherAttributeName[*].value")
+	tt.Equal(t, "[e4 e5 e6]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "e4", pretty.SEN(path.First(data)))
+
+	// a non-existent attribute in the struct and also in the json (which populated the struct)
+	// would still be non-existent as expected
+	path = jp.MustParseString("$.nonExistentAttributeName[*].value")
+	tt.Equal(t, "[]", pretty.SEN(path.Get(data)))
+}
+
+func TestGetChildReflectByJsonTagInEmbeddedStruct(t *testing.T) {
+	type Base struct {
+		BaseVal string `json:"anyOtherAttributeName"`
+	}
+	type Element struct {
+		Base  // Embedded Struct
+		Value string
+	}
+	type Root struct {
+		Elements []Element
+	}
+	data := Root{
+		Elements: []Element{
+			{Base: Base{BaseVal: "b1"}, Value: "e1"},
+			{Base: Base{BaseVal: "b2"}, Value: "e2"},
+			{Base: Base{BaseVal: "b3"}, Value: "e3"},
+		},
+	}
+	path := jp.MustParseString("$.elements[*]")
+	tt.Equal(t, "[{baseVal: b1 value: e1} {baseVal: b2 value: e2} {baseVal: b3 value: e3}]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "{baseVal: b1 value: e1}", pretty.SEN(path.First(data)))
+
+	path = jp.MustParseString("$.elements[*].value")
+	tt.Equal(t, "[e1 e2 e3]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "e1", pretty.SEN(path.First(data)))
+
+	path = jp.MustParseString("$.elements[*].baseVal")
+	tt.Equal(t, "[b1 b2 b3]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "b1", pretty.SEN(path.First(data)))
+
+	// Get by "json" tag
+	path = jp.MustParseString("$.elements[*].anyOtherAttributeName")
+	tt.Equal(t, "[b1 b2 b3]", pretty.SEN(path.Get(data)))
+	tt.Equal(t, "b1", pretty.SEN(path.First(data)))
+
+	// a non-existent attribute in the struct and also in the json (which populated the struct)
+	// would still be non-existent as expected
+	path = jp.MustParseString("$.elements[*].nonExistentAttributeName")
+	tt.Equal(t, "[]", pretty.SEN(path.Get(data)))
+}
+
 func TestGetSliceReflect(t *testing.T) {
 	src := "$.vals[-3:]"
 	data := map[string]any{"vals": []int{10, 20, 30, 40, 50, 60}}


### PR DESCRIPTION
Related to #133 

I took as a basis the original function that was being used before: `rd.FieldByNameFunc()` (line 1590)

but as the original function did not provide the type `reflect.StructField`, only the field name, the adjustments I made were just to support this feature.

I ask you to check (diff) the PR code against the original function to see what I changed:
`reflect.FieldByNameFunc(match func(string) bool)`
https://cs.opensource.google/go/go/+/master:src/reflect/type.go;l=1025?q=type.go&ss=go%2Fgo