### PR TITLE
Fixed a bug where ampersand character (&) was escaped in Child operators

### DIFF
--- a/jp/expr_test.go
+++ b/jp/expr_test.go
@@ -61,6 +61,9 @@ func TestExprBuild(t *testing.T) {
 
 	x = jp.R().Child("").Child("a")
 	tt.Equal(t, `$[''].a`, x.String())
+
+	x = jp.R().Child("a & b")
+	tt.Equal(t, `$['a & b']`, x.String())
 }
 
 func TestExprFilter(t *testing.T) {

--- a/jp/string.go
+++ b/jp/string.go
@@ -12,7 +12,7 @@ var (
 	//   0123456789abcdef0123456789abcdef
 	jMap = "" +
 		`........btn.fr..................` + // 0x00
-		`oo"oooh'oooooooooooooooooooooooo` + // 0x20
+		`oo"oooo'oooooooooooooooooooooooo` + // 0x20
 		`oooooooooooooooooooooooooooo\ooo` + // 0x40
 		"ooooooooooooooooooooooooooooooo." + // 0x60
 		`88888888888888888888888888888888` + // 0x80

--- a/jp/string_test.go
+++ b/jp/string_test.go
@@ -16,6 +16,7 @@ func TestString(t *testing.T) {
 	}
 	for i, td := range []*Data{
 		{src: "abc", expect: `|abc|`},
+		{src: "&", expect: `|&|`},
 		{src: "a\tbc", expect: `|a\tbc|`},
 		{src: "a<b>c", expect: `|a<b>c|`},
 		{src: "a 𝄢 note", expect: `|a 𝄢 note|`},


### PR DESCRIPTION
This PR fixes what seems to be a bug in the string serialisation for expressions.

The ampersand `&` character got escaped into `\h` which, besides not being the right string, also isn't a valid according to `jp.ParseString`, eg (https://go.dev/play/p/BDjHacoE4Hu):

```go
package main

import (
	"fmt"
	"github.com/ohler55/ojg/jp"
)

func main() {
	original := jp.R().C("a & b")
	_, err := jp.ParseString(original.BracketString())
	fmt.Println(err)
}

```
Shows the error:
```
0x68 (h) is not a valid escaped character
```

I've added some basic tests covering this, but I'm unfamiliar with other parts of the code. I think the only place this is relevant is in https://github.com/ohler55/ojg/blob/aede9eca61caea2834d4521db8238614991550b4/string.go#L61-L69, where it seems to be parting HTML, where `&` is special. I think the mapping got copied over and this bug sneaked in.