### PR TITLE
Support Indexed and Keyed interfaces when removing nodes

### DIFF
--- a/jp/child.go
+++ b/jp/child.go
@@ -48,6 +48,8 @@ func (f Child) remove(value any) (out any, changed bool) {
 		if _, changed = tv[key]; changed {
 			delete(tv, key)
 		}
+	case Keyed:
+		tv.RemoveValueForKey(key)
 	default:
 		if rt := reflect.TypeOf(value); rt != nil {
 			// Can't remove a field from a struct so only a map can be modified.

--- a/jp/filter.go
+++ b/jp/filter.go
@@ -98,7 +98,7 @@ func (f Filter) remove(value any) (out any, changed bool) {
 				changed = true
 			}
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		for i := (size - 1); i >= 0; i-- {
 			v := tv.ValueAtIndex(i)
@@ -219,7 +219,7 @@ func (f Filter) removeOne(value any) (out any, changed bool) {
 				}
 			}
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		for i := 0; i < size; i++ {
 			v := tv.ValueAtIndex(i)

--- a/jp/filter.go
+++ b/jp/filter.go
@@ -98,6 +98,24 @@ func (f Filter) remove(value any) (out any, changed bool) {
 				changed = true
 			}
 		}
+	case Indexed:
+		size := tv.Size()
+		for i := (size - 1); i >= 0; i-- {
+			v := tv.ValueAtIndex(i)
+			if f.Match(v) {
+				tv.RemoveValueAtIndex(i)
+				changed = true
+			}
+		}
+	case Keyed:
+		keys := tv.Keys()
+		for _, key := range keys {
+			v, _ := tv.ValueForKey(key)
+			if f.Match(v) {
+				tv.RemoveValueForKey(key)
+				changed = true
+			}
+		}
 	default:
 		rv := reflect.ValueOf(value)
 		switch rv.Kind() {
@@ -199,6 +217,27 @@ func (f Filter) removeOne(value any) (out any, changed bool) {
 					changed = true
 					break
 				}
+			}
+		}
+	case Indexed:
+		size := tv.Size()
+		for i := 0; i < size; i++ {
+			v := tv.ValueAtIndex(i)
+			if f.Match(v) {
+				tv.RemoveValueAtIndex(i)
+				changed = true
+				break
+			}
+		}
+	case Keyed:
+		keys := tv.Keys()
+		sort.Strings(keys)
+		for _, key := range keys {
+			v, _ := tv.ValueForKey(key)
+			if f.Match(v) {
+				tv.RemoveValueForKey(key)
+				changed = true
+				break
 			}
 		}
 	default:

--- a/jp/indexed.go
+++ b/jp/indexed.go
@@ -13,9 +13,15 @@ type Indexed interface {
 	// SetValueAtIndex should set the value at the provided index.
 	SetValueAtIndex(index int, value any)
 
-	// RemoveValueAtIndex removes an item from the collection.
-	RemoveValueAtIndex(index int)
-
 	// Size should return the size for the collection.
 	Size() int
+}
+
+// RemovableIndexed describes an indexed collection that can remove items.
+// Must be implemented to use [Expr.Remove].
+type RemovableIndexed interface {
+	Indexed
+
+	// RemoveValueAtIndex removes an item from the collection.
+	RemoveValueAtIndex(index int)
 }

--- a/jp/indexed.go
+++ b/jp/indexed.go
@@ -13,6 +13,9 @@ type Indexed interface {
 	// SetValueAtIndex should set the value at the provided index.
 	SetValueAtIndex(index int, value any)
 
+	// RemoveValueAtIndex removes an item from the collection.
+	RemoveValueAtIndex(index int)
+
 	// Size should return the size for the collection.
 	Size() int
 }

--- a/jp/nth.go
+++ b/jp/nth.go
@@ -59,6 +59,15 @@ func (f Nth) remove(value any) (out any, changed bool) {
 			out = append(tv[:i], tv[i+1:]...)
 			changed = true
 		}
+	case Indexed:
+		size := tv.Size()
+		if i < 0 {
+			i = size + i
+		}
+		if 0 <= i && i < size {
+			tv.RemoveValueAtIndex(i)
+			changed = true
+		}
 	default:
 		if rt := reflect.TypeOf(value); rt != nil {
 			if rt.Kind() == reflect.Slice {

--- a/jp/nth.go
+++ b/jp/nth.go
@@ -59,7 +59,7 @@ func (f Nth) remove(value any) (out any, changed bool) {
 			out = append(tv[:i], tv[i+1:]...)
 			changed = true
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		if i < 0 {
 			i = size + i

--- a/jp/ordered_test.go
+++ b/jp/ordered_test.go
@@ -64,6 +64,13 @@ func (o *ordered) SetValueAtIndex(index int, value any) {
 	}
 }
 
+func (o *ordered) RemoveValueAtIndex(index int) {
+	if 0 <= index && index < len(o.entries) {
+		copy(o.entries[index:], o.entries[index+1:])
+		o.entries = o.entries[:len(o.entries)-1]
+	}
+}
+
 type keyed struct {
 	ordered
 }

--- a/jp/slice.go
+++ b/jp/slice.go
@@ -138,6 +138,26 @@ func (f Slice) remove(value any) (out any, changed bool) {
 		if changed {
 			out = ns
 		}
+	case Indexed:
+		size := tv.Size()
+		if start < 0 {
+			start = size + start
+		}
+		if end < 0 {
+			end = size + end
+		}
+		if size <= end {
+			end = size - 1
+		}
+		if start < 0 || end < 0 || size <= start || size <= end || step == 0 {
+			return
+		}
+		for i := size - 1; 0 <= i; i-- {
+			if inStep(i, start, end, step) {
+				changed = true
+				tv.RemoveValueAtIndex(i)
+			}
+		}
 	default:
 		rv := reflect.ValueOf(value)
 		if rv.Kind() == reflect.Slice {
@@ -283,6 +303,27 @@ func (f Slice) removeOne(value any) (out any, changed bool) {
 		}
 		if changed {
 			out = ns
+		}
+	case Indexed:
+		size := tv.Size()
+		if start < 0 {
+			start = size + start
+		}
+		if end < 0 {
+			end = size + end
+		}
+		if size <= end {
+			end = size - 1
+		}
+		if start < 0 || end < 0 || size <= start || size <= end || step == 0 {
+			return
+		}
+		for i := 0; i < size; i++ {
+			if inStep(i, start, end, step) {
+				changed = true
+				tv.RemoveValueAtIndex(i)
+				break
+			}
 		}
 	default:
 		rv := reflect.ValueOf(value)

--- a/jp/slice.go
+++ b/jp/slice.go
@@ -138,7 +138,7 @@ func (f Slice) remove(value any) (out any, changed bool) {
 		if changed {
 			out = ns
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		if start < 0 {
 			start = size + start
@@ -304,7 +304,7 @@ func (f Slice) removeOne(value any) (out any, changed bool) {
 		if changed {
 			out = ns
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		if start < 0 {
 			start = size + start

--- a/jp/union.go
+++ b/jp/union.go
@@ -127,6 +127,25 @@ func (f Union) removeOne(value any) (out any, changed bool) {
 				}
 			}
 		}
+	case Indexed:
+		size := tv.Size()
+		for i := 0; i < size; i++ {
+			if f.hasN(int64(i)) {
+				tv.RemoveValueAtIndex(i)
+				changed = true
+				break
+			}
+		}
+	case Keyed:
+		keys := tv.Keys()
+		sort.Strings(keys)
+		for _, k := range keys {
+			if f.hasKey(k) {
+				tv.RemoveValueForKey(k)
+				changed = true
+				break
+			}
+		}
 	default:
 		rv := reflect.ValueOf(value)
 		switch rv.Kind() {
@@ -213,6 +232,22 @@ func (f Union) remove(value any) (out any, changed bool) {
 		for k := range tv {
 			if f.hasKey(k) {
 				delete(tv, k)
+				changed = true
+			}
+		}
+	case Indexed:
+		size := tv.Size()
+		for i := (size - 1); i >= 0; i-- {
+			if f.hasN(int64(i)) {
+				tv.RemoveValueAtIndex(i)
+				changed = true
+			}
+		}
+	case Keyed:
+		keys := tv.Keys()
+		for _, k := range keys {
+			if f.hasKey(k) {
+				tv.RemoveValueForKey(k)
 				changed = true
 			}
 		}

--- a/jp/union.go
+++ b/jp/union.go
@@ -127,7 +127,7 @@ func (f Union) removeOne(value any) (out any, changed bool) {
 				}
 			}
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		for i := 0; i < size; i++ {
 			if f.hasN(int64(i)) {
@@ -235,7 +235,7 @@ func (f Union) remove(value any) (out any, changed bool) {
 				changed = true
 			}
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		for i := (size - 1); i >= 0; i-- {
 			if f.hasN(int64(i)) {

--- a/jp/wildcard.go
+++ b/jp/wildcard.go
@@ -55,6 +55,20 @@ func (f Wildcard) remove(value any) (out any, changed bool) {
 				delete(tv, k)
 			}
 		}
+	case Indexed:
+		size := tv.Size()
+		for i := (size - 1); i >= 0; i-- {
+			changed = true
+			tv.RemoveValueAtIndex(i)
+		}
+	case Keyed:
+		keys := tv.Keys()
+		if 0 < len(keys) {
+			changed = true
+			for _, k := range keys {
+				tv.RemoveValueForKey(k)
+			}
+		}
 	default:
 		rv := reflect.ValueOf(value)
 		switch rv.Kind() {
@@ -105,6 +119,18 @@ func (f Wildcard) removeOne(value any) (out any, changed bool) {
 			}
 			sort.Strings(keys)
 			delete(tv, keys[0])
+		}
+	case Indexed:
+		if 0 < tv.Size() {
+			changed = true
+			tv.RemoveValueAtIndex(0)
+		}
+	case Keyed:
+		keys := tv.Keys()
+		if 0 < len(keys) {
+			changed = true
+			sort.Strings(keys)
+			tv.RemoveValueForKey(keys[0])
 		}
 	default:
 		rv := reflect.ValueOf(value)

--- a/jp/wildcard.go
+++ b/jp/wildcard.go
@@ -55,7 +55,7 @@ func (f Wildcard) remove(value any) (out any, changed bool) {
 				delete(tv, k)
 			}
 		}
-	case Indexed:
+	case RemovableIndexed:
 		size := tv.Size()
 		for i := (size - 1); i >= 0; i-- {
 			changed = true
@@ -120,7 +120,7 @@ func (f Wildcard) removeOne(value any) (out any, changed bool) {
 			sort.Strings(keys)
 			delete(tv, keys[0])
 		}
-	case Indexed:
+	case RemovableIndexed:
 		if 0 < tv.Size() {
 			changed = true
 			tv.RemoveValueAtIndex(0)


### PR DESCRIPTION
This PR adds support for the `Indexed` and `Keyed` interfaces when removing nodes from an expression.

Note: I needed to add a method for removing items from `Indexed`. If you'd rather avoid a breaking change, we could move `RemoveValueAtIndex` to a separate interface. I originally went down that route, but got stuck trying to come up with a name. `MutableIndexed` was the only thing I could come up with and... it doesn't really sound great to me 😬. Let me know what you prefer (or feel free to take over this PR).

Also, a belated thank you for fixing #156 ❤️! I tried out the latest release and it works great. 

 