### PR TITLE
fix: allow filtering on custom named types

### DIFF
--- a/jp/script.go
+++ b/jp/script.go
@@ -376,8 +376,23 @@ func (s *Script) evalWithRoot(stack, data, root any) (any, Expr) {
 }
 
 func normalize(v any) any {
+	// handle special values
+	if v == Nothing {
+		return v
+	}
+
+	if v == nil {
+		return nil
+	}
+
 Start:
 	switch tv := v.(type) {
+	// optimize for already normalized values
+	case bool:
+	case int64:
+	case float64:
+	case string:
+	// handle inter-convertible values
 	case int:
 		v = int64(tv)
 	case int8:
@@ -407,12 +422,43 @@ Start:
 	case gen.Float:
 		v = float64(tv)
 	default:
-		if rt := reflect.TypeOf(v); rt != nil && rt.Kind() == reflect.Ptr {
-			rv := reflect.ValueOf(v)
+		switch rv := reflect.ValueOf(v); rv.Kind() {
+		// recursively handle pointers
+		case reflect.Ptr:
 			if !rv.IsNil() {
 				v = rv.Elem().Interface()
 				goto Start
 			}
+
+		// handle named types that implement common types
+		case reflect.Bool:
+			v = rv.Bool()
+		case reflect.Int:
+			v = rv.Int()
+		case reflect.Int8:
+			v = rv.Int()
+		case reflect.Int16:
+			v = rv.Int()
+		case reflect.Int32:
+			v = rv.Int()
+		case reflect.Int64:
+			v = rv.Int()
+		case reflect.Uint:
+			v = int64(rv.Uint())
+		case reflect.Uint8:
+			v = int64(rv.Uint())
+		case reflect.Uint16:
+			v = int64(rv.Uint())
+		case reflect.Uint32:
+			v = int64(rv.Uint())
+		case reflect.Uint64:
+			v = int64(rv.Uint())
+		case reflect.Float32:
+			v = rv.Float()
+		case reflect.Float64:
+			v = rv.Float()
+		case reflect.String:
+			v = rv.String()
 		}
 	}
 	return v
@@ -673,7 +719,6 @@ func evalStack(sstack []any) []any {
 				case float64:
 					if tr != 0.0 {
 						sstack[i] = float64(tl) / tr
-
 					}
 				}
 			case float64:

--- a/jp/script_test.go
+++ b/jp/script_test.go
@@ -184,6 +184,7 @@ func TestScriptNormalizeEval(t *testing.T) {
 		result, _ := s.Eval([]any{}, []any{v}).([]any)
 		tt.Equal(t, 1, len(result), fmt.Sprintf("%T %v", v, v))
 	}
+
 	s, err = jp.NewScript("(@ == 'x')")
 	tt.Nil(t, err)
 	result, _ := s.Eval([]any{}, []any{"x"}).([]any)
@@ -195,6 +196,48 @@ func TestScriptNormalizeEval(t *testing.T) {
 	tt.Nil(t, err)
 	result, _ = s.Eval([]any{}, gen.Array{gen.True}).([]any)
 	tt.Equal(t, 1, len(result), "bool normalize")
+
+	type (
+		customBool    bool
+		customInt     int
+		customInt8    int8
+		customInt16   int16
+		customInt32   int32
+		customInt64   int64
+		customUint    uint
+		customUint8   uint8
+		customUint16  uint16
+		customUint32  uint32
+		customUint64  uint64
+		customFloat32 float32
+		customFloat64 float64
+		customString  string
+	)
+
+	for _, tc := range []struct {
+		v         any
+		scriptStr string
+	}{
+		{customBool(true), "(@ == true)"},
+		{customInt(3), "(@ == 3)"},
+		{customInt8(3), "(@ == 3)"},
+		{customInt16(3), "(@ == 3)"},
+		{customInt32(3), "(@ == 3)"},
+		{customInt64(3), "(@ == 3)"},
+		{customUint(3), "(@ == 3)"},
+		{customUint8(3), "(@ == 3)"},
+		{customUint16(3), "(@ == 3)"},
+		{customUint32(3), "(@ == 3)"},
+		{customUint64(3), "(@ == 3)"},
+		{customFloat32(3.0), "(@ == 3.0)"},
+		{customFloat64(3.0), "(@ == 3.0)"},
+		{customString("x"), "(@ == 'x')"},
+	} {
+		s, err = jp.NewScript(tc.scriptStr)
+		tt.Nil(t, err)
+		result, _ = s.Eval([]any{}, []any{tc.v}).([]any)
+		tt.Equal(t, 1, len(result), fmt.Sprintf("custom type %T normalize", tc.v))
+	}
 }
 
 func TestScriptNonListEval(t *testing.T) {


### PR DESCRIPTION
A custom named type being:

```
type Color string
```

A filter expression on the value `"blue"` would work normally, while on the value `Color("blue")` it would silently never match.

This was unexpected and (as far as I could tell) undocumented behavior, so I decided to fix by supporting custom named types for all common types.