### PR TITLE
Reduce jp.Parse allocations

### DIFF
--- a/jp/parse.go
+++ b/jp/parse.go
@@ -72,7 +72,7 @@ func Parse(buf []byte) (x Expr, err error) {
 
 // MustParse parses a []byte into an Expr and panics on error.
 func MustParse(buf []byte) (x Expr) {
-	p := &parser{buf: buf}
+	p := parser{buf: buf}
 	x = p.readExpr()
 	if p.pos < len(buf) {
 		p.raise("parse error")
@@ -81,7 +81,7 @@ func MustParse(buf []byte) (x Expr) {
 }
 
 func (p *parser) readExpr() (x Expr) {
-	x = Expr{}
+	x = make(Expr, 0, 4)
 	var f Frag
 	first := true
 	lastDescent := false
@@ -141,7 +141,7 @@ func (p *parser) afterDot() Frag {
 	if len(p.buf) <= p.pos {
 		p.raise("not terminated")
 	}
-	var token []byte
+	start := p.pos
 	b := p.buf[p.pos]
 	p.pos++
 	switch b {
@@ -153,35 +153,26 @@ func (p *parser) afterDot() Frag {
 		if tokenMap[b] == '.' {
 			p.raise("an expression fragment can not start with a '%c'", b)
 		}
-		token = append(token, b)
 	}
 	for p.pos < len(p.buf) {
-		b := p.buf[p.pos]
-		p.pos++
-		if tokenMap[b] == '.' {
-			p.pos--
+		if tokenMap[p.buf[p.pos]] == '.' {
 			break
 		}
-		token = append(token, b)
+		p.pos++
 	}
-	return Child(token)
+	return Child(p.buf[start:p.pos])
 }
 
 func (p *parser) afterDotDot() Frag {
-	var token []byte
-	b := p.buf[p.pos]
+	start := p.pos
 	p.pos++
-	token = append(token, b)
 	for p.pos < len(p.buf) {
-		b := p.buf[p.pos]
-		p.pos++
-		if tokenMap[b] == '.' {
-			p.pos--
+		if tokenMap[p.buf[p.pos]] == '.' {
 			break
 		}
-		token = append(token, b)
+		p.pos++
 	}
-	return Child(token)
+	return Child(p.buf[start:p.pos])
 }
 
 func (p *parser) afterBracket() Frag {


### PR DESCRIPTION
This reduces allocations in `jp.Parse` by avoiding temporary token buffers while scanning dot and recursive-descent child fragments.

The parser previously built a temporary `[]byte` with repeated `append` calls, then converted it to `Child`. This patch records the token start offset, advances `p.pos` until the fragment boundary, and converts the original input slice directly to `Child`. It also keeps the parser value on the stack in `MustParse` and preallocates the expression slice with a small capacity for the common short JSONPath case.

Validation:

```text
go test -count=1 ./...
```

I also ran a temporary differential oracle against the previous parser over 10,058 inputs covering fixed examples from the parser tests, bracket notation, quoted children, unions, slices, filters, invalid syntax, Unicode, escaped strings, and deterministic randomized expressions/byte strings. The candidate output matched the previous parser exactly for `String()`, `BracketString()`, and error text.

Benchmark command:

```text
go test -run '^$' -bench '^BenchmarkParse$' -benchmem -count=20 ./jp
```

`benchstat`:

```text
Parse-10  175.7n ± 0%  ->  149.4n ± 0%  -14.97% (p=0.000 n=20)
Parse-10  374.0 B/op   ->  326.0 B/op   -12.83% (p=0.000 n=20)
Parse-10  12.00 allocs ->  10.00 allocs -16.67% (p=0.000 n=20)
```

I found the candidate while experimenting with Sleepy, then reduced the generated patch to the smaller token-scanning change above and validated it manually.

Sleepy proof page - https://sleepy.run/proof
