### PR TITLE
sen: fix panic on malformed '+' string concatenation

### DIFF
--- a/sen/parser.go
+++ b/sen/parser.go
@@ -132,6 +132,7 @@ func (p *Parser) Parse(buf []byte, args ...any) (any, error) {
 	p.line = 1
 	p.mode = valueMap
 	p.mi = 0
+	p.plus = false
 	var err error
 	// Skip BOM if present.
 	if 3 < len(buf) && buf[0] == 0xEF {
@@ -199,6 +200,7 @@ func (p *Parser) ParseReader(r io.Reader, args ...any) (data any, err error) {
 	p.noff = -1
 	p.line = 1
 	p.mi = 0
+	p.plus = false
 	buf := make([]byte, readBufSize)
 	eof := false
 	var cnt int
@@ -526,6 +528,12 @@ func (p *Parser) parseBuffer(buf []byte, last bool) (err error) {
 			}
 			off += i
 		case valPlus:
+			// Concatenation with '+' requires a preceding string operand.
+			// Reject malformed input such as a leading '+' or a '+' after a
+			// non-string value here instead of panicking later in addString().
+			if !p.concatOperandOK() {
+				return p.newError(off, "unexpected character '%c'", b)
+			}
 			p.mode = plusMap
 			// Store additional state (plus) to be used later in addString()
 			// instead of creating another set of modes for this semi-rare
@@ -800,6 +808,27 @@ func (p *Parser) addTokenWith(s string, off int) {
 	default:
 		p.stack = append(p.stack, s)
 	}
+}
+
+// concatOperandOK reports whether the value that a '+' concatenation would
+// extend is present and is a string. It guards against malformed input (a
+// leading '+' with nothing on the stack, or a '+' following a non-string
+// value) that would otherwise panic in addString().
+func (p *Parser) concatOperandOK() bool {
+	if 0 < len(p.starts) && p.starts[len(p.starts)-1] == -1 { // object value
+		if 0 < len(p.stack) {
+			if obj, ok := p.stack[len(p.stack)-1].(map[string]any); ok {
+				_, ok = obj[string(p.lastKey)].(string)
+				return ok
+			}
+		}
+		return false
+	}
+	if 0 < len(p.stack) {
+		_, ok := p.stack[len(p.stack)-1].(string)
+		return ok
+	}
+	return false
 }
 
 func (p *Parser) addString(s string, off int) {

--- a/sen/parser_test.go
+++ b/sen/parser_test.go
@@ -553,3 +553,48 @@ func TestParserCComment(t *testing.T) {
 	v = sen.MustParse([]byte(src))
 	tt.Equal(t, []any{"abc", "ghi"}, v)
 }
+
+// TestParserParseConcat exercises the '+' string-concatenation operator,
+// including malformed uses that must return an error rather than panic.
+func TestParserParseConcat(t *testing.T) {
+	// Valid concatenations.
+	for _, d := range []rdata{
+		{src: `["a" + "b"]`, value: []any{"ab"}},
+		{src: `["a" + "b" + "c"]`, value: []any{"abc"}},
+		{src: `[abc + "d"]`, value: []any{"abcd"}},
+		{src: `{x:"a" + "b"}`, value: map[string]any{"x": "ab"}},
+		{src: `{x:"a" + "b" + "c"}`, value: map[string]any{"x": "abc"}},
+	} {
+		var p sen.Parser
+		v, err := p.Parse([]byte(d.src))
+		tt.Nil(t, err, d.src)
+		tt.Equal(t, d.value, v, d.src)
+	}
+
+	// Malformed uses of '+' must error, not panic. A leading '+' has no
+	// operand and a '+' after a non-string value has no string to extend.
+	for _, src := range []string{
+		`+""`,
+		`+"x"`,
+		`[1 +"x"]`,
+		`[true +"x"]`,
+		`[null +"x"]`,
+		`{x:1 +"y"}`,
+	} {
+		var p sen.Parser
+		_, err := p.Parse([]byte(src))
+		tt.NotNil(t, err, src)
+	}
+}
+
+// TestParserParseConcatReuse verifies that a parser reused after a failed
+// parse that ended mid-concatenation does not carry the concatenation state
+// into the next parse (which previously caused an index-out-of-range panic).
+func TestParserParseConcatReuse(t *testing.T) {
+	var p sen.Parser
+	_, err := p.Parse([]byte(`["a" +`)) // incomplete, leaves concat pending
+	tt.NotNil(t, err)
+	v, err := p.Parse([]byte(`""`))
+	tt.Nil(t, err)
+	tt.Equal(t, "", v)
+}


### PR DESCRIPTION
### Summary

The SEN parser's `+` string-concatenation operator assumes there is already a string value to extend. Malformed input that uses `+` without such an operand reaches `addString` in a bad state and panics, so any caller of `sen.Parse` on untrusted input can be crashed.

Two shapes, both panic today:

```go
sen.Parse([]byte(`+""`))      // panic: runtime error: index out of range [0] with length 0
sen.Parse([]byte(`+"x"`))     // same
sen.Parse([]byte(`[1 +"x"]`)) // panic: interface conversion: interface {} is int64, not string
```

- A leading `+` sets the concatenation flag with an empty stack; the following string then completes a "value" while the stack is empty, and the top-level value read indexes an empty slice.
- A `+` after a non-string value (number, bool, null) makes the concatenation do an unchecked `.(string)` assertion on the previous value.

There is also a reuse angle: a parser whose previous parse failed part-way through a concatenation kept the concat flag set, so the next parse could panic on otherwise-fine input. This matters because `sen.Parse` gets parsers from a pooled/reused `sync.Parser`.

### Fix

- Validate at the `+` token that a string operand is actually present; if not, return a normal parse error instead of proceeding into the panic.
- Clear the per-parse concat flag when a parser is (re)used, next to the other per-parse resets in `Parse`/`ParseReader`.

Valid concatenation is unchanged:

```
["a" + "b"]        => [ab]
["a" + "b" + "c"]  => [abc]
{x:"a" + "b"}      => map[x:ab]
[abc + "d"]        => [abcd]
```

### Tests

Added `TestParserParseConcat` (valid concatenations plus malformed `+` inputs that must now error rather than panic) and `TestParserParseConcatReuse` (reuse after a failed mid-concatenation parse must not panic). Both fail on `develop` and pass with this change; the full `sen`/`oj`/`jp` suites still pass.
