### PR TITLE
ci: update checkout and setup-go to v7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -27,10 +27,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v7
       with:
         go-version: 1.24
 


### PR DESCRIPTION
Updates CI workflow actions to current major versions.

Changes:
- actions/checkout v4 -> v7
- actions/setup-go v4 -> v7

Validation:
- workflow YAML parses locally (jobs: golangci, test)
- no removed inputs in use; setup-go v7 keeps go-version input

Scope: .github/workflows/CI.yml only.

Note: this PR comes from a fork, so workflow runs may need maintainer approval before they start.
