### PR TITLE
jp: fix hang and panic on an empty slice range in Locate

### DIFF
--- a/jp/locate_test.go
+++ b/jp/locate_test.go
@@ -199,6 +199,8 @@ func TestExprLocateReflect(t *testing.T) {
 		{path: "[1,2]", data: []int{1, 2, 3}, expect: []string{"[1]", "[2]"}},
 		{path: "[1:2]", data: nil, expect: []string{}},
 		{path: "[1:3]", data: []int{1, 2, 3}, expect: []string{"[1]", "[2]"}},
+		{path: "[2:0]", data: []int{1, 2, 3}, expect: []string{}},
+		{path: "[5:]", data: []int{1, 2, 3}, expect: []string{}},
 		{path: "[1:3]", max: 1, data: []int{1, 2, 3}, expect: []string{"[1]"}},
 		{path: "[2:0:-1]", max: 1, data: []int{1, 2, 3}, expect: []string{"[2]"}},
 		{path: "[0:3].b", max: 1, data: []map[string]any{{"a": 1}, {"b": 1}}, expect: []string{"[1].b"}},

--- a/jp/slice.go
+++ b/jp/slice.go
@@ -478,6 +478,9 @@ func (f Slice) locate(pp Expr, data any, rest Expr, max int) (locs []Expr) {
 		switch rt.Kind() {
 		case reflect.Slice, reflect.Array:
 			start, end, step := f.startEndStep(rd.Len())
+			if step == 0 {
+				return
+			}
 			if 0 < step {
 				if len(rest) == 0 { // last one
 					for i := start; i <= end; i += step {


### PR DESCRIPTION
`jp.MustParseString("[2:0]").Locate([]int{1, 2, 3}, 0)` never comes back. It appends `[2]` over and over agian until the process runs out of memory. `[1:1]`, `[0:-5]` and `[-9:-8]` do the same, and `[5:]` panics with `reflect: slice index out of range` instead. All five return an empty result over `[]any{1, 2, 3}`, so its only when the data is a Go-typed slice or array that you hit it.

`startEndStep` uses `step == 0` to mean the range is empty and there's nothing to walk. The `[]any`, `gen.Array` and `Indexed` cases of `Slice.locate` each check for it as their first statement. The reflect case is the only one that doesnt, so `0 < step` is false and it drops into the reverse loop with `i += 0`.

`Get`, `Has`, `Set` and `Remove` all check the sentinel. So Locate looks like the only entry point affected. I've put a row per shape in `TestExprLocateReflect`, though it's worth saying the empty-range one will hang the suite rather than fail it if this ever comes back.
