### PR TITLE
jp: fix panic when a filter is applied to a nil document

### DIFF
--- a/jp/locate_test.go
+++ b/jp/locate_test.go
@@ -213,6 +213,8 @@ func TestExprLocateReflect(t *testing.T) {
 		{path: "$.*", max: 2, data: []int{1, 2, 3}, expect: []string{"$[0]", "$[1]"}},
 		{path: "$.*.a", max: 1, data: []map[string]any{{"a": 1}}, expect: []string{"$[0].a"}},
 		{path: "$..", data: nil, expect: []string{"$"}},
+		{path: "[?(@.x > 1)]", data: nil, expect: []string{}},
+		{path: "$..[?(@.x)]", data: nil, expect: []string{}},
 		{path: "$..", data: &Sample{A: 3, B: "sample"}, expect: []string{"$", "$.A", "$.B"}},
 		{path: "$..", max: 2, data: &Sample{A: 3, B: "sample"}, expect: []string{"$", "$.B"}},
 		{path: "$..", max: 2, data: []int{1, 2, 3}, expect: []string{"$", "$[0]"}},

--- a/jp/script.go
+++ b/jp/script.go
@@ -229,7 +229,9 @@ func (s *Script) evalWithRoot(stack, data, root any) (any, Expr) {
 		data = da
 	default:
 		rv := reflect.ValueOf(td)
-		if rt := rv.Type(); rt.Kind() == reflect.Pointer {
+		// Kind() is used instead of Type().Kind() since data can be nil, and
+		// Type() panics on the zero Value while Kind() returns reflect.Invalid.
+		if rv.Kind() == reflect.Pointer {
 			rv = rv.Elem()
 		}
 		if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {

--- a/jp/script_test.go
+++ b/jp/script_test.go
@@ -247,6 +247,31 @@ func TestScriptNonListEval(t *testing.T) {
 	tt.Equal(t, 0, len(result))
 }
 
+func TestScriptNilDataEval(t *testing.T) {
+	// A filter against a nil document (JSON null) must return nothing rather
+	// than panic, the same as every other fragment type does.
+	for _, src := range []string{
+		"[?(@.x > 1)]",
+		"[?(@.x)]",
+		"[?(@ > 1)]",
+		"[?(@.a == 'x')]",
+		"[?(!@.x)]",
+		"$..[?(@.x)]",
+	} {
+		x, err := jp.ParseString(src)
+		tt.Nil(t, err)
+
+		tt.Equal(t, 0, len(x.Get(nil)), src)
+		tt.Equal(t, 0, len(x.Locate(nil, 0)), src)
+		tt.Equal(t, nil, x.First(nil), src)
+		tt.Equal(t, false, x.Has(nil), src)
+
+		got, found := x.FirstFound(nil)
+		tt.Equal(t, nil, got, src)
+		tt.Equal(t, false, found, src)
+	}
+}
+
 func TestScriptEval(t *testing.T) {
 	for i, d := range []edata{
 		{src: "(@ == 3)", value: int64(3)},


### PR DESCRIPTION
## Problem

Applying a filter to a `nil` document panics:

```go
jp.MustParseString("$[?(@.x > 1)]").Get(nil)
// panic: reflect: call of reflect.Value.Type on zero Value
```

`nil` is not an exotic input here — a JSON `null` parses to exactly that, so this is reachable straight off a parse of untrusted input:

```go
data := oj.MustParseString("null") // nil
jp.MustParseString("$[?(@.x > 1)]").Get(data)
```

`Script.evalWithRoot` falls through to a reflect-based branch for data it does not recognize, and that branch calls `rv.Type()` before checking the value is usable. `reflect.ValueOf(nil)` returns the zero `Value`, and `Type()` panics on it.

Every other fragment type already returns nothing for a `nil` document — `$.a`, `$[0]`, `$.*`, `$..*`, `$[0:2]`, `$['a']` all come back empty. A filter was the only one that panicked, so this is also an inconsistency within `jp` rather than only a crash.

It is not limited to `Get`. The same panic comes out of `First`, `FirstFound`, `Has` and `Locate`, and applies to descent filters (`$..[?(@.x)]`), existence filters (`$[?(@.x)]`), comparisons, negation and regex matches alike. A sweep over 25 filter expressions × 13 document shapes × 11 `jp` entry points hit it 130 times, all from this one line.

## Fix

Use `rv.Kind()` instead of `rv.Type().Kind()`. `Kind()` reports `reflect.Invalid` for the zero `Value` rather than panicking, and is identical to `Type().Kind()` for every valid value — so the existing slice/array check immediately below now rejects `nil` the same way it already rejects any other non-list, and the redundant `Type()` call goes away.

After the change a filter on a `nil` document behaves like every other selector:

```
$[?(@.x > 1)]   Get=[] (len 0)  Locate=len 0  FirstFound=(<nil>,false)  Has=false
$.a             Get=[] (len 0)  Locate=len 0  FirstFound=(<nil>,false)  Has=false
```

Filters over real data are unaffected, including the reflect branch this line sits in (`[]rec`, `*[]rec`, and a nil `*[]rec` all still behave as before).

## Test plan

- `TestScriptNilDataEval` in `jp/script_test.go`, a companion to the existing `TestScriptNonListEval`, covering six filter shapes across `Get`, `Locate`, `First`, `Has` and `FirstFound`.
- Two rows added to the `TestExprLocateReflect` table in `jp/locate_test.go`, alongside the existing `data: nil` cases.
- Reverting **only** `jp/script.go` to `0419196` and keeping the new tests: both tests panic. With the fix: `go test ./...` is green across every package.
- `golangci-lint run ./jp/...` (the linter CI uses) reports **0 issues**; `go vet ./jp/...`, `staticcheck ./jp/...` and `gofmt -l` are clean. The pre-existing `unsafe.Pointer` vet warnings in `alt/` are untouched by this change.
- Re-running the sweep after the fix: 130 panics → 0.

I left `CHANGELOG.md` alone since it looks like you update it yourself at release time.

One thing I noticed while sweeping but did **not** touch, as it is a different root cause in a different file: `Set`/`SetOne` panic with `assignment to entry in nil map` on a typed nil map (`x.Set(map[string]any(nil), 1)`) rather than returning an error. Happy to open that separately if it is worth fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
