### PR TITLE
Render non-string map keys instead of reflect's placeholder

### DIFF
--- a/oj/mapkey_test.go
+++ b/oj/mapkey_test.go
@@ -1,0 +1,46 @@
+package oj_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ohler55/ojg/oj"
+	"github.com/ohler55/ojg/tt"
+)
+
+type mapKey string
+
+func (k mapKey) String() string { return "stringer:" + string(k) }
+
+func TestMarshalNonStringMapKey(t *testing.T) {
+	// Matches encoding/json, which renders integer map keys as their decimal form.
+	src := map[int]string{1: "a", 2: "b"}
+	std, err := json.Marshal(src)
+	tt.Nil(t, err)
+	b, err := oj.Marshal(src)
+	tt.Nil(t, err)
+	tt.Equal(t, `{"1":"a","2":"b"}`, sorted(string(b)))
+	tt.Equal(t, string(std), sorted(string(b)))
+
+	// Indented writer path.
+	tt.Equal(t, "{\n  \"1\": \"a\"\n}", oj.JSON(map[int]string{1: "a"}, 2))
+
+	// Sort must order by the rendered key, not by the empty reflect string.
+	tt.Equal(t, `{"1":"a","2":"b"}`, oj.JSON(src, &oj.Options{Sort: true}))
+
+	// A string-derived key keeps its own value even when it is a fmt.Stringer,
+	// which is what encoding/json does.
+	ks := map[mapKey]int{"k": 1}
+	std, err = json.Marshal(ks)
+	tt.Nil(t, err)
+	tt.Equal(t, `{"k":1}`, oj.JSON(ks))
+	tt.Equal(t, string(std), oj.JSON(ks))
+}
+
+// sorted normalizes Go's random map iteration order for the two-entry case.
+func sorted(s string) string {
+	if s == `{"2":"b","1":"a"}` {
+		return `{"1":"a","2":"b"}`
+	}
+	return s
+}

--- a/oj/tight.go
+++ b/oj/tight.go
@@ -266,7 +266,7 @@ func (wr *Writer) tightMap(rv reflect.Value, si *sinfo) {
 	wr.buf = append(wr.buf, '{')
 	keys := rv.MapKeys()
 	if wr.Sort {
-		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(keys[i].String(), keys[j].String()) })
+		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(ojg.KeyString(keys[i]), ojg.KeyString(keys[j])) })
 	}
 	comma := false
 	for _, kv := range keys {
@@ -279,32 +279,32 @@ func (wr *Writer) tightMap(rv reflect.Value, si *sinfo) {
 		}
 		switch rm.Kind() {
 		case reflect.Struct:
-			wr.buf = ojg.AppendJSONString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendJSONString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.tightStruct(rm, si)
 		case reflect.Slice, reflect.Array:
 			if (wr.OmitNil || wr.OmitEmpty) && rm.Len() == 0 {
 				continue
 			}
-			wr.buf = ojg.AppendJSONString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendJSONString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.tightSlice(rm, si)
 		case reflect.Map:
 			if (wr.OmitNil || wr.OmitEmpty) && rm.Len() == 0 {
 				continue
 			}
-			wr.buf = ojg.AppendJSONString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendJSONString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.tightMap(rm, si)
 		case reflect.String:
 			if (wr.OmitNil || wr.OmitEmpty) && rm.Len() == 0 {
 				continue
 			}
-			wr.buf = ojg.AppendJSONString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendJSONString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.appendJSON(rm.Interface(), 0)
 		default:
-			wr.buf = ojg.AppendJSONString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendJSONString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.appendJSON(rm.Interface(), 0)
 		}

--- a/oj/writer.go
+++ b/oj/writer.go
@@ -677,7 +677,7 @@ func (wr *Writer) appendSlice(rv reflect.Value, depth int, si *sinfo) {
 func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 	keys := rv.MapKeys()
 	if wr.Sort {
-		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(keys[i].String(), keys[j].String()) })
+		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(ojg.KeyString(keys[i]), ojg.KeyString(keys[j])) })
 	}
 	d2 := depth + 1
 	var is string
@@ -721,7 +721,7 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 		switch rm.Kind() {
 		case reflect.Struct:
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendStruct(rm, d2, si)
 		case reflect.Slice, reflect.Array:
@@ -729,7 +729,7 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 				continue
 			}
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendSlice(rm, d2, si)
 		case reflect.Map:
@@ -737,7 +737,7 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 				continue
 			}
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendMap(rm, d2, si)
 		case reflect.String:
@@ -745,12 +745,12 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 				continue
 			}
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendJSON(rm.Interface(), d2)
 		default:
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendJSON(rm.Interface(), d2)
 		}

--- a/sen/tight.go
+++ b/sen/tight.go
@@ -270,7 +270,7 @@ func (wr *Writer) tightMap(rv reflect.Value, si *sinfo) {
 	wr.buf = append(wr.buf, '{')
 	keys := rv.MapKeys()
 	if wr.Sort {
-		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(keys[i].String(), keys[j].String()) })
+		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(ojg.KeyString(keys[i]), ojg.KeyString(keys[j])) })
 	}
 	comma := false
 	for _, kv := range keys {
@@ -286,32 +286,32 @@ func (wr *Writer) tightMap(rv reflect.Value, si *sinfo) {
 		}
 		switch rm.Kind() {
 		case reflect.Struct:
-			wr.buf = ojg.AppendSENString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendSENString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.tightStruct(rm, si)
 		case reflect.Slice, reflect.Array:
 			if (wr.OmitNil || wr.OmitEmpty) && rm.Len() == 0 {
 				continue
 			}
-			wr.buf = ojg.AppendSENString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendSENString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.tightSlice(rm, si)
 		case reflect.Map:
 			if (wr.OmitNil || wr.OmitEmpty) && rm.Len() == 0 {
 				continue
 			}
-			wr.buf = ojg.AppendSENString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendSENString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.tightMap(rm, si)
 		case reflect.String:
 			if (wr.OmitNil || wr.OmitEmpty) && rm.Len() == 0 {
 				continue
 			}
-			wr.buf = ojg.AppendSENString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendSENString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.appendSEN(rm.Interface(), 0)
 		default:
-			wr.buf = ojg.AppendSENString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = ojg.AppendSENString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ':')
 			wr.appendSEN(rm.Interface(), 0)
 		}

--- a/sen/writer.go
+++ b/sen/writer.go
@@ -677,7 +677,7 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 	}
 	keys := rv.MapKeys()
 	if wr.Sort {
-		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(keys[i].String(), keys[j].String()) })
+		sort.Slice(keys, func(i, j int) bool { return 0 > strings.Compare(ojg.KeyString(keys[i]), ojg.KeyString(keys[j])) })
 	}
 	empty := true
 	wr.buf = append(wr.buf, '{')
@@ -695,7 +695,7 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 		switch rm.Kind() {
 		case reflect.Struct:
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendStruct(rm, d2, si)
 		case reflect.Slice, reflect.Array:
@@ -703,7 +703,7 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 				continue
 			}
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendSlice(rm, d2, si)
 		case reflect.Map:
@@ -711,7 +711,7 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 				continue
 			}
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendMap(rm, d2, si)
 		case reflect.String:
@@ -719,12 +719,12 @@ func (wr *Writer) appendMap(rv reflect.Value, depth int, si *sinfo) {
 				continue
 			}
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendSEN(rm.Interface(), d2)
 		default:
 			wr.buf = append(wr.buf, cs...)
-			wr.buf = wr.appendString(wr.buf, kv.String(), !wr.HTMLUnsafe)
+			wr.buf = wr.appendString(wr.buf, ojg.KeyString(kv), !wr.HTMLUnsafe)
 			wr.buf = append(wr.buf, ": "...)
 			wr.appendSEN(rm.Interface(), d2)
 		}

--- a/string.go
+++ b/string.go
@@ -3,6 +3,8 @@
 package ojg
 
 import (
+	"fmt"
+	"reflect"
 	"unicode/utf8"
 )
 
@@ -201,4 +203,14 @@ func AppendSENString(buf []byte, s string, htmlSafe bool) []byte {
 	copy(buf[b0:], buf[b0+1:])
 
 	return buf[:len(buf)-1]
+}
+
+// KeyString returns the string form of a reflect map key. Keys that are not
+// strings are formatted with the fmt package the same way alt.reflectMap
+// formats them.
+func KeyString(kv reflect.Value) string {
+	if kv.Kind() == reflect.String {
+		return kv.String()
+	}
+	return fmt.Sprint(kv.Interface())
 }


### PR DESCRIPTION
ojg writes bytes ojg cannot read back:

```go
b, _ := oj.Marshal(map[int]string{1: "a", 2: "b"})
// {"<int Value>":"a","<int Value>":"b"}
v, _ := oj.Parse(b)
// map[<int Value>:b]      <- one entry, the other silently lost
```

The JSON and SEN writers call `reflect.Value.String()` on the map key, which returns `"<int Value>"` for any non-string kind rather than the key's value. `encoding/json` gives `{"1":"a","2":"b"}`, and `alt/alt.go:22` documents `GoOptions` as "the options that match the go json.Marshal behavior" — which is what `oj.Marshal` runs on.

`alt/decompose.go:289-291` already handles this, falling back to `fmt.Sprint` for a non-string key. The four writers never got that treatment: `0844e7e` ("Non string map keys", your #186) fixed `jp/get.go` and stopped there.

The `Sort: true` comparators are included — on `develop` they compare `""` against `""` for these maps, so sorting is a silent no-op.

<details>
<summary>Verification</summary>

| row | result |
|---|---|
| new test on `develop` | FAIL, `expect {"1":"a","2":"b"}` |
| with the fix | PASS |
| `KeyString` always `kv.String()` | FAIL |
| drop the `Kind() == String` fast path | FAIL |

The last row matters: without the fast path, a string-derived key that implements `fmt.Stringer` goes through `fmt.Sprint` and its `String()` method fires, giving `{"stringer:k":1}` where both `encoding/json` and `develop` give `{"k":1}`. The test has a row for that.

`go test ./...` green on all 9 packages; `gofmt` clean; `golangci-lint run ./...` 0 issues. `go vet` reports `possible misuse of unsafe.Pointer` in `alt/fbool.go` and `alt/ffloat32.go` — identical on `develop`, files I do not touch, and vet is not a CI step.

Two things worth your call. `KeyString` is exported from the root package because `oj/` and `sen/` both need it; if you would rather keep it unexported I can duplicate a small helper in each. And `pretty` and `cmd/oj` render maps through paths I did not touch — the suite is green, but you may want one consistent pass.

Note this also changes `map[float64]T` and `map[bool]T`, which `encoding/json` rejects outright; ojg now renders them as `{"1.5":"x"}` and `{"true":1}` rather than the placeholder. Happy to error on those instead if you prefer strict stdlib parity.
</details>

---

Disclosure: I used Claude (an AI assistant) while preparing this change.
