### PR TITLE
jp: return an error instead of panicking on a nil map

### DIFF
--- a/jp/set.go
+++ b/jp/set.go
@@ -116,6 +116,10 @@ func (x Expr) set(data, value any, fun string, one bool) error {
 			var has bool
 			switch tv := prev.(type) {
 			case map[string]any:
+				// A nil map can not be written to, but deleting from one is a no-op.
+				if tv == nil && value != delFlag {
+					return fmt.Errorf("can not %s into a nil %T at '%s'", fun, tv, x[:fi+1])
+				}
 				if int(fi) == len(x)-1 { // last one
 					if value == delFlag {
 						delete(tv, string(tf))
@@ -210,6 +214,10 @@ func (x Expr) set(data, value any, fun string, one bool) error {
 					}
 				}
 			case gen.Object:
+				// A nil map can not be written to, but deleting from one is a no-op.
+				if tv == nil && value != delFlag {
+					return fmt.Errorf("can not %s into a nil %T at '%s'", fun, tv, x[:fi+1])
+				}
 				if int(fi) == len(x)-1 { // last one
 					if value == delFlag {
 						delete(tv, string(tf))
@@ -770,6 +778,10 @@ func (x Expr) set(data, value any, fun string, one bool) error {
 					var has bool
 					switch tv := prev.(type) {
 					case map[string]any:
+						// A nil map can not be written to, but deleting from one is a no-op.
+						if tv == nil && value != delFlag {
+							return fmt.Errorf("can not %s into a nil %T at '%s'", fun, tv, x[:fi+1])
+						}
 						if int(fi) == len(x)-1 { // last one
 							if value == delFlag {
 								delete(tv, tu)
@@ -826,6 +838,10 @@ func (x Expr) set(data, value any, fun string, one bool) error {
 							}
 						}
 					case gen.Object:
+						// A nil map can not be written to, but deleting from one is a no-op.
+						if tv == nil && value != delFlag {
+							return fmt.Errorf("can not %s into a nil %T at '%s'", fun, tv, x[:fi+1])
+						}
 						if int(fi) == len(x)-1 { // last one
 							if value == delFlag {
 								delete(tv, tu)

--- a/jp/set_test.go
+++ b/jp/set_test.go
@@ -899,6 +899,59 @@ func TestSetMapPtrNil(t *testing.T) {
 	tt.Nil(t, data["a"])
 }
 
+func TestSetNilMap(t *testing.T) {
+	// Writing a key into a nil map used to panic with "assignment to entry in
+	// nil map". An error is returned instead. Both the Child and the Union
+	// fragments write a known key, for simple maps and for gen.Object.
+	for _, d := range []struct {
+		path string
+		data any
+		err  string
+	}{
+		{path: "a", data: map[string]any(nil),
+			err: "can not set into a nil map[string]interface {} at 'a'"},
+		{path: "a.b", data: map[string]any(nil),
+			err: "can not set into a nil map[string]interface {} at 'a'"},
+		{path: "a.b", data: map[string]any{"a": map[string]any(nil)},
+			err: "can not set into a nil map[string]interface {} at 'a.b'"},
+		{path: "['a','b']", data: map[string]any(nil),
+			err: "can not set into a nil map[string]interface {} at '['a','b']'"},
+		{path: "a", data: gen.Object(nil),
+			err: "can not set into a nil gen.Object at 'a'"},
+		{path: "a.b", data: gen.Object{"a": gen.Object(nil)},
+			err: "can not set into a nil gen.Object at 'a.b'"},
+		{path: "['a','b']", data: gen.Object(nil),
+			err: "can not set into a nil gen.Object at '['a','b']'"},
+	} {
+		x, err := jp.ParseString(d.path)
+		tt.Nil(t, err, d.path)
+
+		var value any = 3
+		if _, ok := d.data.(gen.Object); ok {
+			value = gen.Int(3)
+		}
+		err = x.Set(d.data, value)
+		tt.NotNil(t, err, d.path)
+		tt.Equal(t, d.err, err.Error(), d.path)
+
+		err = x.SetOne(d.data, value)
+		tt.NotNil(t, err, d.path)
+		tt.Equal(t, d.err, err.Error(), d.path)
+	}
+}
+
+func TestDelNilMap(t *testing.T) {
+	// Deleting from a nil map is a no-op, not an error.
+	for _, path := range []string{"a", "a.b", "['a','b']", "*", "..a"} {
+		x, err := jp.ParseString(path)
+		tt.Nil(t, err, path)
+		tt.Nil(t, x.Del(map[string]any(nil)), path)
+		tt.Nil(t, x.DelOne(map[string]any(nil)), path)
+		tt.Nil(t, x.Del(gen.Object(nil)), path)
+		tt.Nil(t, x.DelOne(gen.Object(nil)), path)
+	}
+}
+
 func TestSetStructPtrNil(t *testing.T) {
 	type A struct {
 		B any


### PR DESCRIPTION
Follows up on your comment in #229. This is independent of that PR and branches from `develop`, so the two can merge in either order.

## Problem

```go
var m map[string]any
jp.MustParseString("$.a").Set(m, 1)
// panic: assignment to entry in nil map
```

`Set`, `SetOne`, `MustSet` and `MustSetOne` all funnel into `Expr.set`, where the `Child` and `Union` fragments write a known key straight into the map.

**The reach is wider than my note in #229 suggested** — I described it as a top-level nil map, but it is any nil `map[string]any` or `gen.Object` reached along the path, at any depth:

| data | path | before |
|---|---|---|
| `map[string]any(nil)` | `$.a` | panic |
| `map[string]any{"a": nil map}` | `$.a.b` | panic |
| `[]any{nil map}` | `$[0].b` | panic |
| `{"a":{"b": nil map}}` | `$.a.b.c` | panic |
| `map[string]any{"a": nil map}` | `$..b` | panic |
| `gen.Object(nil)` | `$.a`, `$['a','b']` | panic |

`gen.Object` is affected the same way, which is why the fix touches both.

`Wildcard` fragments were never affected: they only write inside a `range` over the map, and a nil map ends that immediately. That is also why `$.*` and `$..*` already returned cleanly while `$.a` panicked.

## Fix

Four guards, one at the top of each map arm that writes a known key (`Child` and `Union`, for `map[string]any` and `gen.Object`), returning the same shape of error the surrounding code already uses for data it cannot write to:

```
can not set into a nil map[string]interface {} at '$.a'
can not set into a nil gen.Object at '$.a.b'
```

The guard is conditioned on `value != delFlag`, so **deleting still works**. `delete` on a nil map is a no-op in Go, and `Del`/`DelOne` returned cleanly before this change — I did not want to turn those into errors. `TestDelNilMap` pins that.

## Test plan

`TestSetNilMap` covers all four guarded branches (`Child`/`Union` × `map[string]any`/`gen.Object`), including nested cases, and asserts on `Set` and `SetOne`. `TestDelNilMap` pins the delete no-op.

- Reverting **only** `jp/set.go` to `0419196` and keeping the tests: `TestSetNilMap` panics with the original `assignment to entry in nil map`. With the fix: `go test ./...` is green across every package.
- `golangci-lint run ./jp/...` reports **0 issues**; `gofmt -l` and `go vet ./jp/...` are clean.
- A sweep of 18 path expressions × 14 document shapes × 10 entry points shows no remaining nil-map panic.

## One more, not fixed here

That sweep turned up a separate panic I have left alone, since it is an array rather than a map and unrelated to this change:

```go
jp.MustParseString("$[0,1]").Set(gen.Array{}, gen.Int(1))
// panic: runtime error: index out of range [0] with length 0
```

It is not nil-specific — an empty `gen.Array` is enough — and `$[0]` on the same data correctly returns `can not follow out of bounds array index`, while `[]any` handles the union fine. Looks like the `Union` path is missing the bounds check the plain `Nth` path has. Happy to send that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
